### PR TITLE
TxLog to Goroutine

### DIFF
--- a/internal/server/handlers/collection.go
+++ b/internal/server/handlers/collection.go
@@ -47,10 +47,7 @@ func (wh wdbHandlers) CreateCollection(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, entities)
 	return nil
 }
 
@@ -81,10 +78,7 @@ func (wh wdbHandlers) FetchCollection(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, entities)
 	return nil
 }
 
@@ -114,9 +108,6 @@ func (wh wdbHandlers) DeleteCollection(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go  wh.handleTransactions(c, resp, entities)
 	return nil
 }

--- a/internal/server/handlers/data.go
+++ b/internal/server/handlers/data.go
@@ -43,10 +43,7 @@ func (wh wdbHandlers) AddData(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, entities)
 	return nil
 }
 
@@ -88,9 +85,7 @@ func (wh wdbHandlers) ReadData(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
+	go wh.handleTransactions(c, resp, entities)
 
 	return nil
 }
@@ -133,10 +128,7 @@ func (wh wdbHandlers) DeleteData(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, entities)
 	return nil
 }
 
@@ -183,9 +175,6 @@ func (wh wdbHandlers) UpdateData(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, entities)
 	return nil
 }

--- a/internal/server/handlers/database.go
+++ b/internal/server/handlers/database.go
@@ -41,9 +41,7 @@ func (wh wdbHandlers) CreateDatabase(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
+	go wh.handleTransactions(c, resp, entities)
 
 	return nil
 }
@@ -72,9 +70,7 @@ func (wh wdbHandlers) FetchDatabase(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
+	go wh.handleTransactions(c, resp, entities)
 
 	return nil
 }
@@ -102,9 +98,6 @@ func (wh wdbHandlers) DeleteDatabase(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, entities)
 	return nil
 }

--- a/internal/server/handlers/hello.go
+++ b/internal/server/handlers/hello.go
@@ -25,9 +25,6 @@ func (wh wdbHandlers) Hello(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, noEntities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, noEntities)
 	return nil
 }

--- a/internal/server/handlers/roles.go
+++ b/internal/server/handlers/roles.go
@@ -42,10 +42,7 @@ func (wh wdbHandlers) CreateRole(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, noEntities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, noEntities)
 	return nil
 }
 
@@ -68,9 +65,6 @@ func (wh wdbHandlers) ListRoles(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, noEntities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, noEntities)
 	return nil
 }

--- a/internal/server/handlers/users.go
+++ b/internal/server/handlers/users.go
@@ -37,9 +37,7 @@ func (wh wdbHandlers) LoginUser(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, noEntities); err != nil {
-		return err
-	}
+	go wh.handleTransactions(c, resp, noEntities)
 
 	return nil
 }
@@ -65,10 +63,7 @@ func (wh wdbHandlers) CreateUser(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, noEntities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, noEntities)
 	return nil
 }
 
@@ -108,10 +103,7 @@ func (wh wdbHandlers) GrantRoles(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, noEntities); err != nil {
-		return err
-	}
-
+	wh.handleTransactions(c, resp, noEntities)
 	return nil
 }
 
@@ -136,9 +128,6 @@ func (wh wdbHandlers) CheckPermissions(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := wh.handleTransactions(c, resp, entities); err != nil {
-		return err
-	}
-
+	go wh.handleTransactions(c, resp, noEntities)
 	return nil
 }

--- a/internal/txlogs/txlogs.go
+++ b/internal/txlogs/txlogs.go
@@ -11,11 +11,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-var (
-	DatabaseTxnEntity   TxnEntityType = "database"
-	CollectionTxnEntity TxnEntityType = "collection"
-)
-
 type TxnEntityType string
 
 type TransactionLogs struct {
@@ -33,7 +28,7 @@ func CreateTxLog(txnAction, txnActor string, txnRequestStatus string, txnEntitie
 		EntityPath:         txnEntities,
 		EntityType:         getEntityType(txnEntities),
 		Status:             getTxnStatus(txnRequestStatus),
-		Timestamp:          float64(time.Now().Unix()),
+		Timestamp:          float64(time.Now().UTC().Unix()),
 		TransactionDetails: txnDetails,
 	}
 }


### PR DESCRIPTION
Closes #101 

- Moved txlog method `handleTransactions` to separate thread with goroutine

Note:
- Might require additional panic handling for goroutine, currently not being handled by the default panic handler in `server/middleware/recovery`, though haven't encountered any panics for current code/tests