### PR TITLE
Apply Mutex lock on Entities

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -437,7 +437,7 @@ Some of the Privileges available for use in wunderDb and associated actions.
 | createUser       | global privilege      | create user                        |
 | createRole       | global privilege      | create roles                       |
 | listRole         | global privilege      | list roles in wdb                  |
-| createDatabase   | global privilege      | create database                    |
+| createDatabase   | user privilege        | create database                    |
 | grantRole        | user privileges       | grant role to user                 |
 | readDatabase     | database privileges   | read/fetch database                |
 | updateDatabase   | database privileges   | update database                    |

--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -12,7 +12,7 @@ const (
 
 type Collections map[model.Identifier]*model.Collection
 
-func UseDatabase(database model.Database) Collections {
+func UseDatabase(database *model.Database) Collections {
 	return Collections(database.Collections)
 }
 

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -49,7 +49,7 @@ func Test_CheckIfExists(t *testing.T) {
 	}
 
 	database := model.Database{Collections: Collections{testCollection1Name: testCollection1}}
-	collection := UseDatabase(database)
+	collection := UseDatabase(&database)
 
 	for _, tc := range testCases {
 		isExists, collection := collection.CheckIfExists(model.Identifier(tc.collectionName))
@@ -62,7 +62,7 @@ func Test_CreateCollection(t *testing.T) {
 	testCollection := Collections{testCollection1Name: testCollection1}
 	database := model.Database{Collections: testCollection}
 
-	collections := UseDatabase(database)
+	collections := UseDatabase(&database)
 	collections.CreateCollection(testCollection2Name, model.Schema{}, model.Access{})
 
 	expectedCollectionsMap := testCollection
@@ -93,7 +93,7 @@ func Test_GetCollection(t *testing.T) {
 	}
 
 	database := model.Database{Collections: Collections{testCollection1Name: testCollection1}}
-	collection := UseDatabase(database)
+	collection := UseDatabase(&database)
 
 	for _, tc := range testCases {
 		fetchedDatabase := collection.GetCollection(model.Identifier(tc.collectionName))
@@ -103,7 +103,7 @@ func Test_GetCollection(t *testing.T) {
 
 func Test_DeleteDatabase(t *testing.T) {
 	database := model.Database{Collections: Collections{testCollection1Name: testCollection1}}
-	collection := UseDatabase(database)
+	collection := UseDatabase(&database)
 	collection.DeleteCollection(testCollection1Name)
 
 	assert.Equal(t, Collections{}, collection)
@@ -122,7 +122,7 @@ func Test_UpdateMetadata(t *testing.T) {
 	}
 
 	database := model.Database{Collections: Collections{testCollection1Name: testCollection1}}
-	collection := UseDatabase(database)
+	collection := UseDatabase(&database)
 	collection.UpdateMetadata(testCollection1Name)
 
 	assert.Equal(t, expectedCollectionsChange[testCollection1Name].Metadata[metadata.CreatedAt], collection[testCollection1Name].Metadata[metadata.CreatedAt])

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -14,7 +14,7 @@ type Data struct {
 	Schema model.Schema
 }
 
-func UseCollection(collection model.Collection) Data {
+func UseCollection(collection *model.Collection) Data {
 	return Data{
 		Data:   collection.Data,
 		Schema: collection.Schema,

--- a/internal/data/data_test.go
+++ b/internal/data/data_test.go
@@ -36,7 +36,7 @@ var (
 
 func Test_HappyDataFlow(t *testing.T) {
 
-	dc := UseCollection(collection)
+	dc := UseCollection(&collection)
 
 	datarow1Id := model.Identifier("1")
 	datarow1 := map[string]interface{}{
@@ -134,7 +134,7 @@ func Test_HappyDataFlow(t *testing.T) {
 }
 
 func Test_AddData_validationError(t *testing.T) {
-	dc := UseCollection(collection)
+	dc := UseCollection(&collection)
 
 	invalidDataSample := map[string]interface{}{
 		"name": "jane",
@@ -147,7 +147,7 @@ func Test_AddData_validationError(t *testing.T) {
 }
 
 func Test_filterMissingError(t *testing.T) {
-	dc := UseCollection(collection)
+	dc := UseCollection(&collection)
 
 	updateData := map[string]interface{}{
 		"name": "jane",
@@ -163,7 +163,7 @@ func Test_filterMissingError(t *testing.T) {
 }
 
 func Test_filterDecodeError(t *testing.T) {
-	dc := UseCollection(collection)
+	dc := UseCollection(&collection)
 
 	invalidFilter := "filter"
 	updateData := map[string]interface{}{

--- a/model/models.go
+++ b/model/models.go
@@ -1,5 +1,7 @@
 package model
 
+import "sync"
+
 type Identifier string
 
 type DataMap map[string]interface{}
@@ -30,6 +32,7 @@ type Database struct {
 	Collections map[Identifier]*Collection `json:"collections"`
 	Metadata    Metadata                   `json:"metadata"`
 	Access      map[Identifier]*Access     `json:"access,omitempty"`
+	sync.Mutex
 }
 
 type Collection struct {

--- a/model/models.go
+++ b/model/models.go
@@ -40,6 +40,7 @@ type Collection struct {
 	Metadata Metadata               `json:"metadata"`
 	Schema   Schema                 `json:"schema"`
 	Access   map[Identifier]*Access `json:"access,omitempty"`
+	sync.Mutex
 }
 
 type Datum struct {

--- a/pkg/wdb/collections.go
+++ b/pkg/wdb/collections.go
@@ -16,7 +16,7 @@ func (wdb wdbClient) AddCollection(databaseId, collectionId model.Identifier, sc
 		return &er.DatabaseDoesNotExistsError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
@@ -42,7 +42,7 @@ func (wdb wdbClient) GetCollection(databaseId, collectionId model.Identifier) (*
 		return nil, &er.DatabaseDoesNotExistsError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 
 	if !wdb.safeName.Check(collectionId.String()) {
 		return nil, &er.CollectionNameFormatError
@@ -65,7 +65,7 @@ func (wdb wdbClient) DeleteCollection(databaseId, collectionId model.Identifier)
 		return &er.DatabaseDoesNotExistsError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError

--- a/pkg/wdb/collections.go
+++ b/pkg/wdb/collections.go
@@ -16,6 +16,9 @@ func (wdb wdbClient) AddCollection(databaseId, collectionId model.Identifier, sc
 		return &er.DatabaseDoesNotExistsError
 	}
 
+	database.Lock()
+	defer database.Unlock()
+
 	collections := c.UseDatabase(database)
 
 	if !wdb.safeName.Check(collectionId.String()) {
@@ -71,9 +74,13 @@ func (wdb wdbClient) DeleteCollection(databaseId, collectionId model.Identifier)
 		return &er.CollectionNameFormatError
 	}
 
-	if exists, _ := collections.CheckIfExists(collectionId); !exists {
+	exists, collection := collections.CheckIfExists(collectionId)
+	if !exists {
 		return &er.CollectionDoesNotExistsError
 	}
+
+	collection.Lock()
+	defer collection.Unlock()
 
 	collections.DeleteCollection(collectionId)
 	wdb.updateParentMetadata(&databaseId, nil)

--- a/pkg/wdb/common.go
+++ b/pkg/wdb/common.go
@@ -13,7 +13,7 @@ func (wdb wdbClient) updateParentMetadata(databaseId, collectionId *model.Identi
 		wdb.Databases.UpdateMetadata(*databaseId)
 		if collectionId != nil {
 			_, database := wdb.Databases.CheckIfExists(*databaseId)
-			collections := collections.UseDatabase(*database)
+			collections := collections.UseDatabase(database)
 			collections.UpdateMetadata(*collectionId)
 		}
 	}

--- a/pkg/wdb/data.go
+++ b/pkg/wdb/data.go
@@ -118,9 +118,6 @@ func (wdb wdbClient) DeleteData(databaseId, collectionId model.Identifier, filte
 		return &er.DatabaseDoesNotExistsError
 	}
 
-	database.Lock()
-	defer database.Unlock()
-
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
 	}

--- a/pkg/wdb/data.go
+++ b/pkg/wdb/data.go
@@ -1,6 +1,8 @@
 package wdbClient
 
 import (
+	"time"
+
 	c "github.com/TanmoySG/wunderDB/internal/collections"
 	d "github.com/TanmoySG/wunderDB/internal/data"
 	"github.com/TanmoySG/wunderDB/internal/identities"
@@ -19,11 +21,15 @@ func (wdb wdbClient) AddData(databaseId, collectionId model.Identifier, inputDat
 		return &er.DatabaseDoesNotExistsError
 	}
 
+	database.Lock()
+	defer database.Unlock()
+	time.Sleep(20 * time.Second)
+
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 	collectionExists, collection := collections.CheckIfExists(collectionId)
 	if !collectionExists {
 		return &er.CollectionDoesNotExistsError
@@ -50,11 +56,14 @@ func (wdb wdbClient) GetData(databaseId, collectionId model.Identifier, filters 
 		return nil, &er.DatabaseDoesNotExistsError
 	}
 
+	database.Lock()
+	defer database.Unlock()
+
 	if !wdb.safeName.Check(collectionId.String()) {
 		return nil, &er.CollectionNameFormatError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 
 	collectionExists, collection := collections.CheckIfExists(collectionId)
 	if !collectionExists {
@@ -81,11 +90,14 @@ func (wdb wdbClient) UpdateData(databaseId, collectionId model.Identifier, updat
 		return &er.DatabaseDoesNotExistsError
 	}
 
+	database.Lock()
+	defer database.Unlock()
+
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 
 	collectionExists, collection := collections.CheckIfExists(collectionId)
 	if !collectionExists {
@@ -112,11 +124,14 @@ func (wdb wdbClient) DeleteData(databaseId, collectionId model.Identifier, filte
 		return &er.DatabaseDoesNotExistsError
 	}
 
+	database.Lock()
+	defer database.Unlock()
+
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
 	}
 
-	collections := c.UseDatabase(*database)
+	collections := c.UseDatabase(database)
 
 	collectionExists, collection := collections.CheckIfExists(collectionId)
 	if !collectionExists {

--- a/pkg/wdb/data.go
+++ b/pkg/wdb/data.go
@@ -19,9 +19,6 @@ func (wdb wdbClient) AddData(databaseId, collectionId model.Identifier, inputDat
 		return &er.DatabaseDoesNotExistsError
 	}
 
-	database.Lock()
-	defer database.Unlock()
-
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
 	}
@@ -32,7 +29,10 @@ func (wdb wdbClient) AddData(databaseId, collectionId model.Identifier, inputDat
 		return &er.CollectionDoesNotExistsError
 	}
 
-	data := d.UseCollection(*collection)
+	collection.Lock()
+	defer collection.Unlock()
+
+	data := d.UseCollection(collection)
 	dataId := identities.GenerateID()
 	err := data.Add(model.Identifier(dataId), inputData)
 	if err != nil {
@@ -53,9 +53,6 @@ func (wdb wdbClient) GetData(databaseId, collectionId model.Identifier, filters 
 		return nil, &er.DatabaseDoesNotExistsError
 	}
 
-	database.Lock()
-	defer database.Unlock()
-
 	if !wdb.safeName.Check(collectionId.String()) {
 		return nil, &er.CollectionNameFormatError
 	}
@@ -67,7 +64,7 @@ func (wdb wdbClient) GetData(databaseId, collectionId model.Identifier, filters 
 		return nil, &er.CollectionDoesNotExistsError
 	}
 
-	data := d.UseCollection(*collection)
+	data := d.UseCollection(collection)
 
 	fetchedData, err := data.Read(filters)
 	if err != nil {
@@ -87,9 +84,6 @@ func (wdb wdbClient) UpdateData(databaseId, collectionId model.Identifier, updat
 		return &er.DatabaseDoesNotExistsError
 	}
 
-	database.Lock()
-	defer database.Unlock()
-
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError
 	}
@@ -101,7 +95,10 @@ func (wdb wdbClient) UpdateData(databaseId, collectionId model.Identifier, updat
 		return &er.CollectionDoesNotExistsError
 	}
 
-	data := d.UseCollection(*collection)
+	collection.Lock()
+	defer collection.Unlock()
+
+	data := d.UseCollection(collection)
 	err := data.Update(updatedData, filters)
 	if err != nil {
 		return err
@@ -135,7 +132,10 @@ func (wdb wdbClient) DeleteData(databaseId, collectionId model.Identifier, filte
 		return &er.CollectionDoesNotExistsError
 	}
 
-	data := d.UseCollection(*collection)
+	collection.Lock()
+	defer collection.Unlock()
+
+	data := d.UseCollection(collection)
 
 	err := data.Delete(filters)
 	if err != nil {

--- a/pkg/wdb/data.go
+++ b/pkg/wdb/data.go
@@ -1,8 +1,6 @@
 package wdbClient
 
 import (
-	"time"
-
 	c "github.com/TanmoySG/wunderDB/internal/collections"
 	d "github.com/TanmoySG/wunderDB/internal/data"
 	"github.com/TanmoySG/wunderDB/internal/identities"
@@ -23,7 +21,6 @@ func (wdb wdbClient) AddData(databaseId, collectionId model.Identifier, inputDat
 
 	database.Lock()
 	defer database.Unlock()
-	time.Sleep(20 * time.Second)
 
 	if !wdb.safeName.Check(collectionId.String()) {
 		return &er.CollectionNameFormatError

--- a/pkg/wdb/databases.go
+++ b/pkg/wdb/databases.go
@@ -25,9 +25,11 @@ func (wdb wdbClient) GetDatabase(databaseId model.Identifier) (*model.Database, 
 		return nil, &er.DatabaseNameFormatError
 	}
 
-	if exists, _ := wdb.Databases.CheckIfExists(databaseId); !exists {
+	exists, _ := wdb.Databases.CheckIfExists(databaseId)
+	if !exists {
 		return nil, &er.DatabaseDoesNotExistsError
 	}
+
 	return wdb.Databases.GetDatabase(databaseId), nil
 }
 
@@ -36,9 +38,14 @@ func (wdb wdbClient) DeleteDatabase(databaseId model.Identifier) *er.WdbError {
 		return &er.DatabaseNameFormatError
 	}
 
-	if exists, _ := wdb.Databases.CheckIfExists(databaseId); !exists {
+	exists, database := wdb.Databases.CheckIfExists(databaseId)
+	if !exists {
 		return &er.DatabaseDoesNotExistsError
 	}
+
+	database.Lock()
+	defer database.Unlock()
+
 	wdb.Databases.DeleteDatabase(databaseId)
 	return nil
 }


### PR DESCRIPTION
Closes #118 

Mutex lock on entities allows to keep all data operations discrete, independent of each other and atomic.