### PR TITLE
Update wunderDb CI/CD Workflows

### DIFF
--- a/.github/workflows/fly-deploy.yaml
+++ b/.github/workflows/fly-deploy.yaml
@@ -17,3 +17,4 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - run: echo "Deployed tag ${{ github.ref_name }} to Fly.io!"

--- a/.github/workflows/wdb-tag-deploy.yaml
+++ b/.github/workflows/wdb-tag-deploy.yaml
@@ -104,3 +104,9 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PUB_TOKEN }}
+
+  post-run:
+    needs: ["ghrc-publish"]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Tag ${{ github.ref_name }} Published!"


### PR DESCRIPTION
Update wunderDb CI/CD Workflows https://github.com/TanmoySG/wunderDB/commit/81c1ddeecbabe392a913ca1e38e4811ae822c9ae

Merge pull request https://github.com/TanmoySG/wunderDB/pull/136 from TanmoySG/fix-workflow

- Closes https://github.com/TanmoySG/wunderDB/issues/135 

In this PR, I updated the workflow to run as dependent steps.

- wdb-tag-deploy workflow is run when a tag is pushed
  - `ci` job does on the Go CI/CD tasks
  - `ghrc-publish` job publishes image to ghrc.io, only if `ci` runs fine
  - `gorelease` job creates release and publishes the brew binary (using go-releaser) only if  `ghrc-publish` runs successfulyy
- fly-deploy workflow runs only if `wdb-tag-deploy` and all its jobs run fine without any issues and deploys to fly.io
- go-ci runs for all PRs and pushes
- codeql-analysis runs for all PR and pushed and also on schedule