### PR TITLE
update archive naming template in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,14 +16,14 @@ builds:
 
 archives:
   - id: wdbctl
-    name_template: "{{.Binary}}_{{.Version}}_{{.Os}}_{{.Arch}}_{{.Arm}}"
+    name_template: "{{.Binary}}_{{.Version}}_{{.Os}}_{{.Arch}}{{.Arm}}"
     builds: [wdbctl]
     format: tar.gz
     files:
       - README.md
       - LICENSE
   - id: wunderdb
-    name_template: "{{.Binary}}_{{.Version}}_{{.Os}}_{{.Arch}}_{{.Arm}}"
+    name_template: "{{.Binary}}_{{.Version}}_{{.Os}}_{{.Arch}}{{.Arm}}"
     builds: [wunderdb]
     format: tar.gz
     files:


### PR DESCRIPTION
This pull request updates the archive naming templates in the `.goreleaser.yaml` configuration file to remove the underscore before the `Arm` field in the `name_template`. This change ensures consistency in the naming convention for build artifacts.

Configuration updates:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L19-R26): Modified the `name_template` for the `wdbctl` and `wunderdb` archives by removing the underscore before the `{{.Arm}}` field.